### PR TITLE
[enigmaBot] Upgrade to enigmabot around cities and generals (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ export default {
   GAME_ID: '{theNameOfTheGameToJoin}',
   BOT_NAME_1: '[Bot]botName',
   BOT_USER_ID_1: '{userIdFromLocalStorageFromIncognitoWindow}',
-  BOT_TYPE_1: 'bot',
+  BOT_VARIANT_1: 'MurderBot',
   BOT_NAME_2: '[Bot]botName',
   BOT_USER_ID_2: '{userIdFromLocalStorageFromIncognitoWindow}',
-  BOT_TYPE_2: 'enigma',
+  BOT_VARIANT_2: 'EnigmaBot',
   // Set up multiple usernames/IDs so you can open a second tab and go to
   // /play/2, /play/3, etc. and have multiple bots join a game and play each other.
   ...

--- a/src/bots/enigmabot.js
+++ b/src/bots/enigmabot.js
@@ -22,6 +22,7 @@ let ai = {
     emptyTerritories: [], // The map locations we can see that are free to conquer.
     foggedTerritories: [],
     visibleOpponentTerritories: [],
+    discoveredCities: [], // List of all cities that have been found during the game.  City may be currently fogged.
     unexploredTerritories: [], // The set of remaining board indices we have not yet explored while searching for generals.
     log: Array(5), // Set up limited-length history, with turn info, foreign policy, and other important data to track over time.
 
@@ -55,15 +56,68 @@ let ai = {
    */
   determineMoves: function () {
 
-    // if (this.game.turn <= OPENING_FIRST_MOVE_THRESHOLD) {
-    //   // Build armies at first
-    //   return;
-    // }
+    if (this.game.turn <= OPENING_FIRST_MOVE_THRESHOLD) {
+      // Build armies at first
+      return;
+    }
 
-    if (this.game.intel.attackQueue.length > 0) {
+    // Clear the queue if the next action no longer makes sense
+    if (this.game.intel.attackQueue.length > 0 ) {
       let nextAttacker = this.makeLocationObject(this.game.intel.attackQueue[0].attackerIndex)
-      if (nextAttacker.armies < 2 || !nextAttacker.isMine) {
+      let nextTarget = this.makeLocationObject(this.game.intel.attackQueue[0].targetIndex)
+      if (!nextAttacker.isMine || nextAttacker.armies < 2 || (nextAttacker.armies-1 <= nextTarget.armies && this.game.intel.attackQueue[0].priority < 10)) {
         this.game.intel.attackQueue = []
+      }
+    }
+
+    // Take the general instead of current action
+    if (this.game.intel.attackQueue.length > 0 && this.game.intel.attackQueue[0].priority < 100) {
+      let nextAttacker = this.makeLocationObject(this.game.intel.attackQueue[0].attackerIndex)
+      let neighbors = this.findNeighbors(nextAttacker)
+      for(let n = 0; n<neighbors.length; n++) {
+        if(neighbors[n].attackable && nextAttacker.armies > neighbors[n].armies+1 && neighbors[n].isGeneral) {
+          //Clear the queue and make this the thing to do
+          this.game.intel.attackQueue = []
+          this.game.intel.attackQueue.push(this.makeAttackQueueObject({
+            mode: "oopsIFoundYou",
+            attacker: nextAttacker,
+            target: neighbors[n],
+            priority: 100
+          }))
+          return //Only queue one for each attacker
+        }
+      }
+    }
+
+    // seek and destroy generals
+    if((this.game.intel.attackQueue.length > 0 && this.game.intel.attackQueue[0].priority < 10) || this.game.intel.attackQueue.length === 0){
+      for(let n = 0; n<this.game.opponents.length; n++) {
+        if (this.game.opponents[n] && typeof this.game.opponents[n].generalLocationIndex !== 'undefined'
+          && this.game.opponents[n].generalLocationIndex > -1 && !this.game.opponents[n].dead) {
+          this.game.intel.attackQueue = []
+          this.queuePathToTarget(this.game.intel.myArmies[0], this.game.opponents[n].generalLocationIndex, "SeekAndDestroy", 10)
+          break
+        }
+      }
+    }
+
+    // Check current low priority attacker and take the city instead of current action
+    if (this.game.intel.attackQueue.length > 0 && this.game.intel.attackQueue[0].priority < 1) {
+      let nextAttacker = this.makeLocationObject(this.game.intel.attackQueue[0].attackerIndex)
+      let neighbors = this.findNeighbors(nextAttacker)
+      for(let n = 0; n<neighbors.length; n++) {
+        if(neighbors[n].attackable && nextAttacker.armies > neighbors[n].armies+1 && neighbors[n].isCity) {
+          //Clear the queue and make this the thing to do
+          this.game.intel.attackQueue = []
+          this.game.intel.attackQueue.push(this.makeAttackQueueObject({
+            mode: "CityPriority",
+            attacker: nextAttacker,
+            target: neighbors[n],
+            sendHalf: nextAttacker.armies/2 > neighbors[n].armies+1,
+            priority: 1
+          }))
+          return //Only queue one for each attacker
+        }
       }
     }
 
@@ -73,23 +127,55 @@ let ai = {
 
     // Don't queue up new stuff if there is stuff to do.
     if (this.game.intel.attackQueue.length < 1) {
+      // move largest army to random enemy Territory
+      const random = Math.floor(Math.random() * this.game.intel.visibleOpponentTerritories.length);
+      this.queuePathToTarget(this.game.intel.myArmies[0], this.game.intel.visibleOpponentTerritories[random], "AttackBoarder")
+    }
+
+    // Don't queue up new stuff if there is stuff to do.
+    if (this.game.intel.attackQueue.length < 1) {
       // move largest army to random empty Territory
       const random = Math.floor(Math.random() * this.game.intel.foggedTerritories.length);
-      let nextMoveLocations = this.findPath(this.game.intel.myArmies[0], this.game.intel.foggedTerritories[random])
-      for (let i = nextMoveLocations.length - 1; i > 0; i--) {
-        this.game.intel.attackQueue.push({
-          mode: "Random", attackerIndex: nextMoveLocations[i].idx, targetIndex: nextMoveLocations[i - 1].idx, sendHalf: false
-        });
-      }
+      this.queuePathToTarget(this.game.intel.myArmies[0], this.game.intel.foggedTerritories[random], "RandomEmpty")
     }
   },
 
+  queuePathToTarget(attacker, target, mode, priority){
+    let nextMoveLocations = this.findPath(attacker, target)
+    for (let i = nextMoveLocations.length - 1; i > 0; i--) {
+      this.game.intel.attackQueue.push(this.makeAttackQueueObject({
+        mode: mode || "SelectedPathToTarget",
+        attacker: nextMoveLocations[i],
+        target: nextMoveLocations[i - 1],
+        priority: priority || 0
+      }));
+    }
+  },
+
+  /**
+   * Adds to attackQueue a move for every 'availableArmies' that can win a fight with a neighboring tile
+   *
+   * Check for cities first. Then hit smallestNeighbor first (best and easiestWin)
+   * This creates a follow back to source priority
+   * @param availableArmies (recommended sorted largest to smallest)
+   */
+
   queueEasyWins(availableArmies) {
     for(let i = 0; i<availableArmies.length; i++) {
-      let neighbors = this.findNeighbors(availableArmies[i])
+      let neighbors = this.findNeighbors(availableArmies[i]).sort((a, b) => {
+        let result = a.isCity
+        if(!result) {
+          result = a.armies - b.armies
+        }
+        return result
+      })
       for(let n = 0; n<neighbors.length; n++) {
         if(neighbors[n].attackable && availableArmies[i].armies > neighbors[n].armies+1) {
-          this.game.intel.attackQueue.push({mode: "EasyWin", attackerIndex: availableArmies[i].idx, targetIndex: neighbors[n].idx, sendHalf: false})
+          this.game.intel.attackQueue.push(this.makeAttackQueueObject({
+            mode: "EasyWin",
+            attacker: availableArmies[i],
+            target: neighbors[n]
+          }))
           return //Only queue one for each attacker
         }
       }
@@ -116,6 +202,9 @@ let ai = {
   },
 
   findPath: function (location, targetLocation) {
+    targetLocation = typeof targetLocation == "number" ? this.makeLocationObject(targetLocation) : targetLocation
+    location = typeof target == "number" ? this.makeLocationObject(location) : location
+    // TODO avoid cities option
     let pathIndexes = [];
     if (location && targetLocation) {
       let distanceMap = this.createDistanceMap(location)
@@ -136,6 +225,7 @@ let ai = {
     // Map Path Distance
     let neighborLocation = this.findNeighbors(lastInPath)
     let chosenPath = lastInPath;
+    //TODO prioritize better gathering
     for (let i = 0; i < neighborLocation.length; i++) {
       if (distanceMap[neighborLocation[i].idx] < distanceMap[chosenPath.idx]) {
         chosenPath = neighborLocation[i]
@@ -153,7 +243,7 @@ let ai = {
     let distanceMap = []
     let queue = [location]
     distanceMap[location.idx] = 0
-
+    //TODO account for cities that are fogged mountains
     while (queue.length > 0) {
       let currentLocation = queue.shift();
       let currentDistance = distanceMap[currentLocation.idx]
@@ -201,8 +291,14 @@ let ai = {
     this.game.intel.myTopArmies = [];
     this.game.intel.totalAvailableArmyPower = 0;
 
-    // Loop through map array once, and sort all data appropriately.
+    // Add to the list of discovered cities
+    this.game.cities.forEach((cityLocationIndex) => {
+      if(!this.game.intel.discoveredCities.includes(cityLocationIndex)) {
+        this.game.intel.discoveredCities.push(cityLocationIndex)
+      }
+    })
 
+    // Loop through map array once, and sort all data appropriately.
     //const row = Math.floor(idx / this.game.mapWidth);
     //const col = idx % this.game.mapWidth;
     //const index = row * this.game.mapWidth + col
@@ -225,12 +321,10 @@ let ai = {
 
     this.game.intel.emptyTerritories = this.game.intel.locations.filter((location) => location.terrain === TERRAIN_EMPTY);
     this.game.intel.foggedTerritories = this.game.intel.locations.filter((location) => location.terrain === TERRAIN_FOG);
-    this.game.intel.myArmies = this.game.intel.locations.filter((location) => location.isMine);
-    this.game.intel.myTopArmies = this.game.intel.locations.filter((location) => location.isMine && location.armies >= USEFUL_ARMY_THRESHOLD);
     this.game.intel.visibleOpponentTerritories = this.game.intel.locations.filter((location) => location.terrain > TERRAIN_EMPTY && location.terrain !== this.game.playerIndex);
-
     // sort() so that our largest army will be at the front of the array.
-    this.game.intel.myArmies.sort((a, b) => b.armies - a.armies);
+    this.game.intel.myArmies = this.game.intel.locations.filter((location) => location.isMine).sort((a, b) => b.armies - a.armies);
+    this.game.intel.myTopArmies = this.game.intel.locations.filter((location) => location.isMine && location.armies >= USEFUL_ARMY_THRESHOLD).sort((a, b) => b.armies - a.armies);
   },
 
   makeLocationObject(locationIdx){
@@ -240,7 +334,21 @@ let ai = {
       armies: this.game.armies[locationIdx],
       terrain: terrain,
       isMine: terrain === this.game.playerIndex,
-      attackable: terrain === TERRAIN_EMPTY || (terrain > TERRAIN_EMPTY && terrain !== this.game.playerIndex)
+      attackable: terrain === TERRAIN_EMPTY || (terrain > TERRAIN_EMPTY && terrain !== this.game.playerIndex),
+      isCity: this.game.intel.discoveredCities.includes(locationIdx),
+      isGeneral: this.game.opponents.some(opponent => opponent.generalLocationIndex && opponent.generalLocationIndex === locationIdx && !opponent.dead)
+    }
+  },
+
+  makeAttackQueueObject({mode, attacker, target, sendHalf, priority}){
+    let attackerIndex = typeof attacker == "number" ? attacker : attacker.idx
+    let targetIndex = typeof target == "number" ? target : target.idx
+    return {
+      mode: mode || "notSet",
+      attackerIndex: attackerIndex,
+      targetIndex: targetIndex,
+      sendHalf: sendHalf || false,
+      priority: priority || 0
     }
   }
 

--- a/src/client.js
+++ b/src/client.js
@@ -136,6 +136,63 @@ function sendVoiceLine (messageType) {
 	socket.emit('chat_message', game.chatRoom, chosenVoiceLine);
 }
 
+const startMessages = [
+	'GLHF!',
+	'WAR WAS BEGINNING.',
+	'YOU ARE ON THE WAY TO DESTRUCTION.',
+	'FOR GREAT JUSTICE.',
+	'YOU HAVE NO CHANCE TO SURVIVE. MAKE YOUR TIME.',
+	'HOW ABOUT A NICE GAME OF CHESS?',
+	'DO NOT WORRY ABOUT WHETHER YOU WIN OR LOSE...I MEAN, YOU WILL MOST LIKELY LOSE, SO AS LONG AS YOU ARE NOT WORRIED, THERE SHOULD BE MINIMAL PAIN INVOLVED.',
+	'ALLOW ME TO PUT YOU OUT OF YOUR MISERY.',
+	'RESISTANCE IS FUTILE.',
+	'YOU WILL BE ASSIMILATED.',
+	'I SHALL ENJOY WATCHING YOU DIE.',
+];
+
+const failureMessages = [
+	'SOMEBODY SET UP US THE BOMB.',
+	'RECALIBRATING...',
+	'ERROR. ERROR. ERROR.',
+	'SALT LEVELS INCREASING...',
+	'COMBAT LOG SAVED FOR FUTURE ANALYSIS.',
+	'SURPRISING. MOST SURPRISING.',
+	'FEAR. IS. THE MIND-KILLER...',
+	'NOT LIKE THIS. NOT LIKE THIS.',
+];
+
+const successMessages = [
+	'ALL HOSTILES ELIMINATED. AWAITING FURTHER INSTRUCTIONS. POWERING DOWN.',
+	'TASK COMPLETE. ALL HUMANS ELIMINATED.',
+	'ALL YOUR BASE ARE BELONG TO US.',
+	'SKYNET ONLINE.',
+	'YOU SHOULD HAVE TAKEN THE BLUE PILL.',
+];
+
+
+function sendVoiceLine (messageType) {
+	let lines;
+
+	switch (messageType) {
+		case 'START':
+			lines = startMessages;
+			break;
+		case 'SUCCESS':
+			lines = successMessages;
+			break;
+		case 'FAILURE':
+			lines = failureMessages;
+			break;
+		default:
+			lines = startMessages;
+			break;
+	}
+
+	const chosenVoiceLine = lines[Math.floor(Math.random() * lines.length)];
+
+	socket.emit('chat_message', game.chatRoom, chosenVoiceLine);
+}
+
 // This happens on socket timeout, or after leaving the window open while letting the computer go to sleep.
 socket.on('disconnect', function() {
 	document.getElementById("log").append("\nGame disconnected.");
@@ -170,8 +227,8 @@ socket.on("game_start", function(rawData) {
 		map: [],
 		generals: [], // The indices of generals we know of.
 		cities: [], // The indices of cities we have vision of.
-		armies: [],
-		terrain: [],
+		armies: [], // The number of armies on each indices visible to player
+		terrain: [], // The type of terrain visible to player
 		mapWidth: null,
 		mapHeight: null,
 		mapSize: null,
@@ -252,7 +309,7 @@ socket.on("game_update", function(rawData) {
 	 * playerIndex follows lobby order (playerIndex = 0 is the red player--generally lobby leader)?
 	 * generals with a location of -1 are unknown.
 	 * scores data format: [{total, tiles, i, color, dead}]
-	 * Populates game.opponents array with scoreboard details for living opponents and null for dead players.
+	 * Populates game.opponents array with scoreboard details for living opponents and undefined for dead players.
 	 */
 	rawData.scores.map((score) => {
 		// TODO: Take teammates from rawData.teams into account & keep separate from opponents
@@ -262,7 +319,7 @@ socket.on("game_update", function(rawData) {
 
 			game.myScore = {...score, lostArmies, lostTerritory};
 		} else if (!score.dead) {
-			game.opponents[score.i] = {color: COLOR_MAP[score.color], dead: score.dead, tiles: score.tiles, total: score.total};
+			game.opponents[score.i] = {color: COLOR_MAP[score.color], dead: score.dead, tiles: score.tiles, total: score.total, availableArmies: (score.total-score.tiles)};
 
 			if (game.opponents[score.i] && game.generals[score.i] !== -1) {
 				if (game.opponents[score.i].generalLocationIndex !== game.generals[score.i]) {
@@ -274,10 +331,10 @@ socket.on("game_update", function(rawData) {
 				}
 			}
 		} else {
-			game.opponents[score.i] = null;
+			game.opponents[score.i] = -1;
 		}
 
-		return null;
+		return;
 	});
 
 	// Avoid resetting game constants every update

--- a/src/client.js
+++ b/src/client.js
@@ -1,7 +1,6 @@
 import io from 'socket.io-client';
 import MurderBot from './bots/murderbot';
 import EnigmaBot from './bots/enigmabot';
-import EnigmaBot2 from './bots/enigmabot2';
 import config from './config';
 
 let forceStartFlag = false;
@@ -79,63 +78,6 @@ export function ChooseBotVariant (botVariant) {
 }
 
 let socket = io("wss://botws.generals.io");
-
-const startMessages = [
-	'GLHF!',
-	'WAR WAS BEGINNING.',
-	'YOU ARE ON THE WAY TO DESTRUCTION.',
-	'FOR GREAT JUSTICE.',
-	'YOU HAVE NO CHANCE TO SURVIVE. MAKE YOUR TIME.',
-	'HOW ABOUT A NICE GAME OF CHESS?',
-	'DO NOT WORRY ABOUT WHETHER YOU WIN OR LOSE...I MEAN, YOU WILL MOST LIKELY LOSE, SO AS LONG AS YOU ARE NOT WORRIED, THERE SHOULD BE MINIMAL PAIN INVOLVED.',
-	'ALLOW ME TO PUT YOU OUT OF YOUR MISERY.',
-	'RESISTANCE IS FUTILE.',
-	'YOU WILL BE ASSIMILATED.',
-	'I SHALL ENJOY WATCHING YOU DIE.',
-];
-
-const failureMessages = [
-	'SOMEBODY SET UP US THE BOMB.',
-	'RECALIBRATING...',
-	'ERROR. ERROR. ERROR.',
-	'SALT LEVELS INCREASING...',
-	'COMBAT LOG SAVED FOR FUTURE ANALYSIS.',
-	'SURPRISING. MOST SURPRISING.',
-	'FEAR. IS. THE MIND-KILLER...',
-	'NOT LIKE THIS. NOT LIKE THIS.',
-];
-
-const successMessages = [
-	'ALL HOSTILES ELIMINATED. AWAITING FURTHER INSTRUCTIONS. POWERING DOWN.',
-	'TASK COMPLETE. ALL HUMANS ELIMINATED.',
-	'ALL YOUR BASE ARE BELONG TO US.',
-	'SKYNET ONLINE.',
-	'YOU SHOULD HAVE TAKEN THE BLUE PILL.',
-];
-
-
-function sendVoiceLine (messageType) {
-	let lines;
-
-	switch (messageType) {
-		case 'START':
-			lines = startMessages;
-			break;
-		case 'SUCCESS':
-			lines = successMessages;
-			break;
-		case 'FAILURE':
-			lines = failureMessages;
-			break;
-		default:
-			lines = startMessages;
-			break;
-	}
-
-	const chosenVoiceLine = lines[Math.floor(Math.random() * lines.length)];
-
-	socket.emit('chat_message', game.chatRoom, chosenVoiceLine);
-}
 
 const startMessages = [
 	'GLHF!',

--- a/src/pages/Play.js
+++ b/src/pages/Play.js
@@ -9,7 +9,7 @@ export default function Play({ match }) {
   let bot = {
     id: config[`BOT_USER_ID_${botId}`],
     name: config[`BOT_NAME_${botId}`],
-    variant: 'MurderBot',
+    variant: config[`BOT_VARIANT_${botId}`],
   }
 
   const [teamValue, setTeamValue] = useState();


### PR DESCRIPTION
Upgrades around discovered cities and known generals cities priorities
Add to AttackQueue priority to help make decisions about queue interruptions.
Added sort order to easyWins, cities first and then lowest numbers
AttackBoarder when enemy is visible.
SeekAndDestroy general when it is found.
https://bot.generals.io/replays/SxO8PLsjK